### PR TITLE
Fixed Casesensitive error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "@fluffy-spoon/inverse-vue",
     "version": "1.0.0",
     "description": "",
-    "main": "dist/src/Index.js",
-    "typings": "./dist/src/Index.d.ts",
+    "main": "dist/src/index.js",
+    "typings": "./dist/src/index.d.ts",
     "scripts": {
         "test": "tsc && ava",
         "build": "tsc"


### PR DESCRIPTION
MacOS gives an import error because the filename is with lowercase and it searches for uppercase.